### PR TITLE
Convert debug setting from 0.7 alpha 1-3.

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -357,6 +357,11 @@ namespace loot {
                 _settings["enableDebugLogging"] = (_settings["Debug Verbosity"].as<unsigned int>() > 0);
                 _settings.remove("Debug Verbosity");
             }
+            else if (_setting["debugVerbosity"]) {
+                // Conversion from 0.7 alpha key
+                _settings["enableDebugLogging"] = (_settings["debugVerbosity"].as<unsigned int>() > 0);
+                _settings.remove("debugVerbosity");
+            }
             else
                 return false;
         }


### PR DESCRIPTION
I realise the alphas are not officially supported, but when it's as easy as this to deal with the old setting, might as well just include it, no?
