### PR TITLE
Skip JS tests for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
   - cmake .. -DPROJECT_ARCH=64 -DPROJECT_STATIC_RUNTIME=OFF -DBUILD_SHARED_LIBS=OFF -DGTEST_ROOT=../../googletest-release-1.7.0
 
 script:
-  - npm test
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm test || true'
   - make tests && ./tests
 
 before_deploy:


### PR DESCRIPTION
The JS tests run on Sauce Labs, which requires a secure connection to be set up, which isn't allowed for pull requests for security reasons, causing the tests to fail.