### PR TITLE
Warn if load order has not been sorted since opening LOOT.

### DIFF
--- a/src/backend/game/game_cache.cpp
+++ b/src/backend/game/game_cache.cpp
@@ -39,13 +39,15 @@ namespace fs = boost::filesystem;
 namespace lc = boost::locale;
 
 namespace loot {
-    GameCache::GameCache() {}
+    GameCache::GameCache() : isLoadOrderSorted(false) {}
+
     GameCache::GameCache(const GameCache& cache) :
         masterlist(cache.masterlist),
         userlist(cache.userlist),
         conditionCache(cache.conditionCache),
         plugins(cache.plugins),
-        messages(cache.messages) {}
+        messages(cache.messages),
+        isLoadOrderSorted(cache.isLoadOrderSorted) {}
 
     GameCache& GameCache::operator=(const GameCache& cache) {
         if (&cache != this) {
@@ -54,6 +56,7 @@ namespace loot {
             conditionCache = cache.conditionCache;
             plugins = cache.plugins;
             messages = cache.messages;
+            isLoadOrderSorted = cache.isLoadOrderSorted;
         }
 
         return *this;
@@ -111,13 +114,21 @@ namespace loot {
     }
 
     std::vector<Message> GameCache::GetMessages() const {
-        return messages;
+        vector<Message> output(messages);
+        if (!isLoadOrderSorted)
+            output.push_back(Message(Message::warn, "You have not sorted your load order this session."));
+
+        return output;
     }
 
     void GameCache::AppendMessage(const Message& message) {
         std::lock_guard<std::mutex> guard(mutex);
 
         messages.push_back(message);
+    }
+
+    void GameCache::SetLoadOrderSorted(bool isLoadOrderSorted) {
+        this->isLoadOrderSorted = isLoadOrderSorted;
     }
 
     void GameCache::ClearCachedConditions() {

--- a/src/backend/game/game_cache.h
+++ b/src/backend/game/game_cache.h
@@ -55,6 +55,8 @@ namespace loot {
         std::vector<Message> GetMessages() const;
         void AppendMessage(const Message& message);
 
+        void SetLoadOrderSorted(bool isLoadOrderSorted);
+
         void ClearCachedConditions();
         void ClearCachedPlugins();
         void ClearMessages();
@@ -64,6 +66,7 @@ namespace loot {
         std::unordered_map<std::string, bool> conditionCache;
         std::unordered_map<std::string, Plugin> plugins;
         std::vector<Message> messages;
+        bool isLoadOrderSorted;
 
         mutable std::mutex mutex;
     };

--- a/src/backend/plugin_sorter.cpp
+++ b/src/backend/plugin_sorter.cpp
@@ -156,6 +156,7 @@ namespace loot {
         // Clear any existing game-specific messages, as these only relate to
         // state that has been changed by sorting.
         game.ClearMessages();
+        game.SetLoadOrderSorted(true);
 
         return plugins;
     }

--- a/src/gui/handler.cpp
+++ b/src/gui/handler.cpp
@@ -161,7 +161,10 @@ namespace loot {
         }
         else if (request == "cancelSort") {
             _lootState.decrementUnappliedChangeCounter();
-            callback->Success("");
+            _lootState.CurrentGame().SetLoadOrderSorted(false);
+
+            YAML::Node node(GetGeneralMessages());
+            callback->Success(JSON::stringify(node));
             return true;
         }
         else if (request == "editorOpened") {

--- a/src/gui/html/js/events.js
+++ b/src/gui/html/js/events.js
@@ -102,13 +102,14 @@ function onSortPlugins() {
     if (!result) {
       return;
     }
+
+    loot.game.globalMessages = result.globalMessages;
+
     /* Check if sorted load order differs from current load order. */
     const loadOrderIsUnchanged = result.plugins.every((plugin, index) => {
       return plugin.name === loot.game.plugins[index].name;
     });
     if (loadOrderIsUnchanged) {
-      loot.game.globalMessages = result.globalMessages;
-
       result.plugins.forEach((plugin) => {
         const existingPlugin = loot.game.plugins.find((item) => {
           return item.name === plugin.name;
@@ -177,12 +178,15 @@ function onApplySort() {
   }).catch(handlePromiseError);
 }
 function onCancelSort() {
-  return loot.query('cancelSort').then(() => {
+  return loot.query('cancelSort').then(JSON.parse).then((messages) => {
     /* Sort UI elements again according to stored old load order. */
     loot.game.plugins = loot.game.oldLoadOrder;
     filterPluginData(loot.game.plugins, loot.filters);
     delete loot.game.loadOrder;
     delete loot.game.oldLoadOrder;
+
+    /* Update general messages */
+    loot.game.globalMessages = messages;
 
     /* Now show the masterlist update buttons, and hide the accept and
        cancel sort buttons. */


### PR DESCRIPTION
The warning is removed when the load order is sorted, but
reinstated if sorting is cancelled. Closes #528.

Note that if sorting is applied, then changes made so that
another sort produces a new load order and this is cancelled,
the message is not reinstated again, as its purposes is to remind
users that simply launching LOOT is not enough, and not to tell
them when another sort may be required.