### PR TITLE
Remove references to LOOT's wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing To LOOT
 ====================
 
-A general guide to contributing to LOOT, may be found on [LOOT's wiki](https://loot.github.io/docs/contributing/How-To-Contribute). Information more specific to this repository is found here.
+A general guide to contributing to LOOT, may be found on [LOOT's website](https://loot.github.io/docs/contributing/How-To-Contribute). Information more specific to this repository is found here.
 
 ## Repository Branching Structure
 

--- a/docs/LOOT Readme.html
+++ b/docs/LOOT Readme.html
@@ -472,7 +472,7 @@ figure > div {
 <h2 id="contrib">Contributing &amp; Support</h2>
 <p>LOOT is very much a community project, and contributions from its users are very welcome, whether they be metadata, translations, code or anything else. The best way to contribute is to <a href="https://loot.github.io/docs/contributing/How-To-Contribute">make changes yourself</a> at GitHub! It's the fastest way to get changes you want applied, and you'll get your name automatically immortalised in our <a href="http://loot.github.io/credits/">credits</a>.
 
-<p>If you encounter an issue with LOOT, check the <a href="https://loot.github.io/docs/help/LOOT-FAQs">Frequently Asked Questions</a> wiki page in case a solution is available there.
+<p>If you encounter an issue with LOOT, check the <a href="https://loot.github.io/docs/help/LOOT-FAQs">Frequently Asked Questions</a> page in case a solution is available there.
 
 <p>Otherwise, general discussion and support takes place in LOOT's official forum thread, which is linked to on <a href="http://loot.github.io">LOOT's homepage</a>.
 


### PR DESCRIPTION
We merged the LOOT wiki into the LOOT web site some time ago. We still have a few references to the wiki lying around though. This is an effort to get rid of those.

See also https://github.com/loot/loot.github.io/commit/d75378e4d941d9f766ecceaaad6acd2c1a4b3c59