### PR TITLE
Issue #990: Don't display plugins as ESMs if they're ESLs

### DIFF
--- a/src/gui/html/elements/loot-plugin-card.js
+++ b/src/gui/html/elements/loot-plugin-card.js
@@ -191,7 +191,7 @@ export default class LootPluginCard extends Polymer.Element {
 
       /* Set icons' visibility */
       this.$.activeTick.hidden = !this.data.isActive;
-      this.$.isMaster.hidden = !this.data.isMaster || this.data.isLightMaster;
+      this.$.isMaster.hidden = !this.data.isMaster;
       this.$.isLightMaster.hidden = !this.data.isLightMaster;
       this.$.isEmpty.hidden = !this.data.isEmpty;
       this.$.loadsArchive.hidden = !this.data.loadsArchive;


### PR DESCRIPTION
All `.esl` files get both the ESL and ESM flag set by the (FO4 & SSE) game engine, but it is possible set the ESL plugin flag on non-`.esl` files, e.g., on otherwise regular `.esp` files. An ESL flagged `.esp` file is *not* considered an ESM as well though, so just because a plugin has `data.isLightMaster` set doesn't mean that it should also be considered as `.isMaster`.

Both the `data.isMaster` and `.isLightMaster` derive from esplugin (via loot-api), which is already clever enough to automatically set flags based on file extension, so this "or"/`||` check is already superfluous anyway.

Fixes https://github.com/loot/loot/issues/990