### PR TITLE
[WIP!] New "LOOT for Mod Authors" section in the documentation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,10 @@ deploy:
       appveyor_repo_tag: true
 
 on_success:
-  - ps: python "$env:APPVEYOR_BUILD_FOLDER\delete_old_bintray_versions.py" -g loot/loot -b loot/snapshots/loot -u wrinklyninja -k $env:bintray_auth_token -t $env:github_auth_token -n 30
+  - ps: |
+      if ($env:bintray_auth_token -And $env:github_auth_token) {
+        python "$env:APPVEYOR_BUILD_FOLDER\delete_old_bintray_versions.py" -g loot/loot -b loot/snapshots/loot -u wrinklyninja -k $env:bintray_auth_token -t $env:github_auth_token -n 30
+      }
   - ps: scripts\appveyor\update_masterlist_branches.ps1
 
 on_finish:

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -31,9 +31,13 @@ For plugin files, having a line with just something like "Version 2.1.3" in the 
 Provide information to LOOT's masterlists
 =========================================
 
-Ideally you would add the information to the masterlist directly and make a pull request, see `How To Contribute`_ for more information on doing it this way. If you're not used to working with git and YAML gives you a headache, you can also provide the information in other ways though, as described in the :doc:`contributing` page.
+Ideally you would add the information to the masterlist directly and make a pull request, see `How To Contribute`_ for more information on doing it this way. If you're not used to working with |git|_ and |YAML|_ gives you a headache, you can also provide the information in other ways though, as described in the :doc:`contributing` page.
 
 .. _How To Contribute: https://loot.github.io/docs/contributing/How-To-Contribute.html
+.. |git| replace:: :command:`git`
+.. _git: https://git-scm.com/
+.. |YAML| replace:: :abbr:`YAML (YAML Ain't Markup Language)`
+.. _YAML: http://yaml.org/
 
 FAQs
 ====

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -1,0 +1,38 @@
+********************
+Mod Authors and LOOT
+********************
+
+As a mod author you will sometimes be asked various questions or get comments related to LOOT or wonder how or why LOOT does something in relation to your mod. The purpose of this article is to hopefully clear up any questions and make sure that your mod(s) and LOOT works as well together as possible.
+
+Provide information to LOOT directly in the mod
+===============================================
+
+Verson strings
+--------------
+
+LOOT parses the "Description" field in plugin files (``.esp``, ``.esm``, and ``.esl`` files) and is also able to check the ``FileVersion`` of ``.exe`` and ``.dll`` files (e.g., SKSE and F4SE plugins). This allows the masterlist to have checks such as whether a mod is the latest version but also enables version compatibility checks. We strongly recommend all plugin authors to include a version directly in the plugin.
+
+For plugin files, having a line with just something like "Version 2.1.3" in the plugin description[#f1]_ makes it the most obvious for LOOT's parsing, but LOOT tries to be smart and thus also recognises a number of other formats (e.g., "v2.1.3" or simply just "2.1.3")[#f2]_. Since LOOT has no way of know what versioning scheme is being used, it will general compare versions using the `Semantic Versioning scheme`_, so it would also make it easier on LOOT if you follow that (or a scheme compatible with it).
+
+.. `Semantic Versioning scheme`: https://semver.org/
+
+(Is there any other metadata that can be provided directly by the mod?)
+-----------------------------------------------------------------------
+
+Working with the LOOT team
+==========================
+
+FAQs
+====
+
+- Users tell me LOOT says that my plugin has dirty edits
+- My mod is incompatible with…
+- My mod needs to be loaded after/before…
+
+.. rubric:: Footnotes
+
+.. [#f1] The plugin description is the ``SNAM`` record of the plugin's File Header and can be added and edited either using `xEdit`_ or via the relevant game's Creation Kit, typically in the window where you also edit masters.
+.. [#f2] The version parsing happens in LOOT API's ```api/helpers/version.cpp```_ which you are welcome to inspect for more details.
+
+.. _xEdit: https://tes5edit.github.io/
+.. _``api/helpers/version.cpp``: https://github.com/loot/loot-api/blob/master/src/api/helpers/version.cpp

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -32,7 +32,8 @@ FAQs
 .. rubric:: Footnotes
 
 .. [#snam_records] The plugin description is the ``SNAM`` record of the plugin's File Header and can be added and edited either using `xEdit`_ or via the relevant game's Creation Kit, typically in the window where you also edit masters.
-.. [#version_format] The version parsing happens in LOOT API's ```api/helpers/version.cpp```_ which you are welcome to inspect for more details.
+.. [#version_format] The version parsing happens in LOOT API's |api/helpers/version.cpp|_ which you are welcome to inspect for more details.
 
 .. _xEdit: https://tes5edit.github.io/
-.. _``api/helpers/version.cpp``: https://github.com/loot/loot-api/blob/master/src/api/helpers/version.cpp
+.. |api/helpers/version.cpp| replace:: :file:`api/helpers/version.cpp`
+.. _api/helpers/version.cpp: https://github.com/loot/loot-api/blob/master/src/api/helpers/version.cpp

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -28,6 +28,12 @@ For plugin files, having a line with just something like "Version 2.1.3" in the 
 (Is there any other metadata that can be provided directly by the mod?)
 -----------------------------------------------------------------------
 
+Provide information to LOOT's masterlists
+=========================================
+
+Ideally you would add the information to the masterlist directly and make a pull request, see `How To Contribute`_ for more information on doing it this way. If you're not used to working with git and YAML gives you a headache, you can also provide the information in other ways though, as described in the :doc:`contributing` page.
+
+.. _How To Contribute: https://loot.github.io/docs/contributing/How-To-Contribute.html
 
 FAQs
 ====

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -10,7 +10,7 @@ Provide information to LOOT directly in the mod
 Verson strings
 --------------
 
-LOOT parses the "Description" field in plugin files (``.esp``, ``.esm``, and ``.esl`` files) and is also able to check the ``FileVersion`` of ``.exe`` and ``.dll`` files (e.g., SKSE and F4SE plugins). This allows the masterlist to have checks such as whether a mod is the latest version but also enables version compatibility checks. We strongly recommend all plugin authors to include a version directly in the plugin.
+LOOT parses the "Description" field in plugin files (:file:`.esp`, :file:`.esm`, and :file:`.esl` files) and is also able to check the ``FileVersion`` of :file:`.exe` and :file:`.dll` files (e.g., :abbr:`SKSE (Skyrim Script Extender)` and :abbr:`F4SE (Fallout 4 Script Extender)` plugins). This allows the masterlist to have checks such as whether a mod is the latest version but also enables version compatibility checks. We strongly recommend all plugin authors to include a version directly in the plugin.
 
 For plugin files, having a line with just something like "Version 2.1.3" in the plugin description [#snam_records]_ makes it the most obvious for LOOT's parsing, but LOOT tries to be smart and thus also recognises a number of other formats (e.g., "v2.1.3" or simply just "2.1.3") [#version_format]_. Since LOOT has no way of know what versioning scheme is being used, it will general compare versions using the `Semantic Versioning scheme`_, so it would also make it easier on LOOT if you follow that (or a scheme compatible with it).
 

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -12,7 +12,7 @@ Verson strings
 
 LOOT parses the "Description" field in plugin files (``.esp``, ``.esm``, and ``.esl`` files) and is also able to check the ``FileVersion`` of ``.exe`` and ``.dll`` files (e.g., SKSE and F4SE plugins). This allows the masterlist to have checks such as whether a mod is the latest version but also enables version compatibility checks. We strongly recommend all plugin authors to include a version directly in the plugin.
 
-For plugin files, having a line with just something like "Version 2.1.3" in the plugin description[#f1]_ makes it the most obvious for LOOT's parsing, but LOOT tries to be smart and thus also recognises a number of other formats (e.g., "v2.1.3" or simply just "2.1.3")[#f2]_. Since LOOT has no way of know what versioning scheme is being used, it will general compare versions using the `Semantic Versioning scheme`_, so it would also make it easier on LOOT if you follow that (or a scheme compatible with it).
+For plugin files, having a line with just something like "Version 2.1.3" in the plugin description [#snam_records]_ makes it the most obvious for LOOT's parsing, but LOOT tries to be smart and thus also recognises a number of other formats (e.g., "v2.1.3" or simply just "2.1.3")[#version_format]_. Since LOOT has no way of know what versioning scheme is being used, it will general compare versions using the `Semantic Versioning scheme`_, so it would also make it easier on LOOT if you follow that (or a scheme compatible with it).
 
 .. `Semantic Versioning scheme`: https://semver.org/
 
@@ -31,8 +31,8 @@ FAQs
 
 .. rubric:: Footnotes
 
-.. [#f1] The plugin description is the ``SNAM`` record of the plugin's File Header and can be added and edited either using `xEdit`_ or via the relevant game's Creation Kit, typically in the window where you also edit masters.
-.. [#f2] The version parsing happens in LOOT API's ```api/helpers/version.cpp```_ which you are welcome to inspect for more details.
+.. [#snam_records] The plugin description is the ``SNAM`` record of the plugin's File Header and can be added and edited either using `xEdit`_ or via the relevant game's Creation Kit, typically in the window where you also edit masters.
+.. [#version_format] The version parsing happens in LOOT API's ```api/helpers/version.cpp```_ which you are welcome to inspect for more details.
 
 .. _xEdit: https://tes5edit.github.io/
 .. _``api/helpers/version.cpp``: https://github.com/loot/loot-api/blob/master/src/api/helpers/version.cpp

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -4,6 +4,15 @@ Mod Authors and LOOT
 
 As a mod author you will sometimes be asked various questions or get comments related to LOOT or wonder how or why LOOT does something in relation to your mod. The purpose of this article is to hopefully clear up any questions and make sure that your mod(s) and LOOT works as well together as possible.
 
+Working with the LOOT team
+==========================
+
+The "regular" LOOT team consists of only a handful of volunteer contributors, across 5+ different games and masterlists, which means we just can't know every intricacy of every mod in combination with any other mod out there—if you've made a mod and have been asked for whether it's compatible with a number of other mods, you know how this is.
+
+We very much appreciate it when mod authors come to us to let us know of discrepancies between how LOOT treats your mod(s) and how you believe it ought to be treated. This can be erraneous messages, getting load ordering wrong, or other information. Keep in mind that LOOT is for an entire load order, so a statement such as "load my mod last" is not very useful, since multiple mods may claim that—and which one of these should really be loaded last then? It's much better to tell us why it needs to load later than what other (types of) mod(s).
+
+Below are listed a number of ways you can work with and provide information to LOOT/the LOOT team.
+
 Provide information to LOOT directly in the mod
 ===============================================
 
@@ -19,8 +28,6 @@ For plugin files, having a line with just something like "Version 2.1.3" in the 
 (Is there any other metadata that can be provided directly by the mod?)
 -----------------------------------------------------------------------
 
-Working with the LOOT team
-==========================
 
 FAQs
 ====

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -12,9 +12,9 @@ Verson strings
 
 LOOT parses the "Description" field in plugin files (``.esp``, ``.esm``, and ``.esl`` files) and is also able to check the ``FileVersion`` of ``.exe`` and ``.dll`` files (e.g., SKSE and F4SE plugins). This allows the masterlist to have checks such as whether a mod is the latest version but also enables version compatibility checks. We strongly recommend all plugin authors to include a version directly in the plugin.
 
-For plugin files, having a line with just something like "Version 2.1.3" in the plugin description [#snam_records]_ makes it the most obvious for LOOT's parsing, but LOOT tries to be smart and thus also recognises a number of other formats (e.g., "v2.1.3" or simply just "2.1.3")[#version_format]_. Since LOOT has no way of know what versioning scheme is being used, it will general compare versions using the `Semantic Versioning scheme`_, so it would also make it easier on LOOT if you follow that (or a scheme compatible with it).
+For plugin files, having a line with just something like "Version 2.1.3" in the plugin description [#snam_records]_ makes it the most obvious for LOOT's parsing, but LOOT tries to be smart and thus also recognises a number of other formats (e.g., "v2.1.3" or simply just "2.1.3") [#version_format]_. Since LOOT has no way of know what versioning scheme is being used, it will general compare versions using the `Semantic Versioning scheme`_, so it would also make it easier on LOOT if you follow that (or a scheme compatible with it).
 
-.. `Semantic Versioning scheme`: https://semver.org/
+.. _`Semantic Versioning scheme`: https://semver.org/
 
 (Is there any other metadata that can be provided directly by the mod?)
 -----------------------------------------------------------------------

--- a/docs/app/modauthors.rst
+++ b/docs/app/modauthors.rst
@@ -2,24 +2,24 @@
 Mod Authors and LOOT
 ********************
 
-As a mod author you will sometimes be asked various questions or get comments related to LOOT or wonder how or why LOOT does something in relation to your mod. The purpose of this article is to hopefully clear up any questions and make sure that your mod(s) and LOOT works as well together as possible.
+As a mod author you will sometimes be asked various questions or get comments related to LOOT or wonder how or why LOOT does something in relation to your mod. The purpose of this article is to hopefully clear up such questions and make sure that your mod(s) and LOOT work as well together as possible.
 
 Working with the LOOT team
 ==========================
 
 The "regular" LOOT team consists of only a handful of volunteer contributors, across 5+ different games and masterlists, which means we just can't know every intricacy of every mod in combination with any other mod out there—if you've made a mod and have been asked for whether it's compatible with a number of other mods, you know how this is.
 
-We very much appreciate it when mod authors come to us to let us know of discrepancies between how LOOT treats your mod(s) and how you believe it ought to be treated. This can be erraneous messages, getting load ordering wrong, or other information. Keep in mind that LOOT is for an entire load order, so a statement such as "load my mod last" is not very useful, since multiple mods may claim that—and which one of these should really be loaded last then? It's much better to tell us why it needs to load later than what other (types of) mod(s).
+We very much appreciate it when mod authors come to us to let us know of discrepancies between how LOOT treats your mod(s) and how you believe it ought to be treated. This can be erraneous messages, getting load ordering wrong, or other information. Keep in mind that LOOT is for an entire load order, so a blanket statement such as "load my mod last" is not very useful, as multiple mods may claim that—and which one of these should really be loaded last then? It's much better to tell us why it needs to load later than what other (types of) mod(s).
 
 Below are listed a number of ways you can work with and provide information to LOOT/the LOOT team.
 
 Provide information to LOOT directly in the mod
 ===============================================
 
-Verson strings
---------------
+Version strings
+---------------
 
-LOOT parses the "Description" field in plugin files (:file:`.esp`, :file:`.esm`, and :file:`.esl` files) and is also able to check the ``FileVersion`` of :file:`.exe` and :file:`.dll` files (e.g., :abbr:`SKSE (Skyrim Script Extender)` and :abbr:`F4SE (Fallout 4 Script Extender)` plugins). This allows the masterlist to have checks such as whether a mod is the latest version but also enables version compatibility checks. We strongly recommend all plugin authors to include a version directly in the plugin.
+LOOT parses the "Description" field in plugin files (:file:`.esp`, :file:`.esm`, and :file:`.esl` files) and is also able to check the ``FileVersion`` attribute of :file:`.exe` and :file:`.dll` files (e.g., :abbr:`SKSE (Skyrim Script Extender)` and :abbr:`F4SE (Fallout 4 Script Extender)` plugins). This allows the masterlist to have checks such as whether a mod is the latest version but also enables version compatibility (and incompatibility!) checks. We strongly recommend all plugin authors to include the version directly in the plugin.
 
 For plugin files, having a line with just something like "Version 2.1.3" in the plugin description [#snam_records]_ makes it the most obvious for LOOT's parsing, but LOOT tries to be smart and thus also recognises a number of other formats (e.g., "v2.1.3" or simply just "2.1.3") [#version_format]_. Since LOOT has no way of know what versioning scheme is being used, it will general compare versions using the `Semantic Versioning scheme`_, so it would also make it easier on LOOT if you follow that (or a scheme compatible with it).
 
@@ -31,7 +31,7 @@ For plugin files, having a line with just something like "Version 2.1.3" in the 
 Provide information to LOOT's masterlists
 =========================================
 
-Ideally you would add the information to the masterlist directly and make a pull request, see `How To Contribute`_ for more information on doing it this way. If you're not used to working with |git|_ and |YAML|_ gives you a headache, you can also provide the information in other ways though, as described in the :doc:`contributing` page.
+Ideally you would add the information to the masterlist directly and make a pull request, see `How To Contribute`_ for more information on doing it this way. If you're not used to working with |git|_ and |YAML|_ gives you a headache, you can also provide the information in other ways, as described on the :doc:`contributing` page.
 
 .. _How To Contribute: https://loot.github.io/docs/contributing/How-To-Contribute.html
 .. |git| replace:: :command:`git`
@@ -42,9 +42,9 @@ Ideally you would add the information to the masterlist directly and make a pull
 FAQs
 ====
 
-- Users tell me LOOT says that my plugin has dirty edits
-- My mod is incompatible with…
-- My mod needs to be loaded after/before…
+* Users tell me LOOT says that my plugin has dirty edits
+* My mod is incompatible with…
+* My mod needs to be loaded after/before…
 
 .. rubric:: Footnotes
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ LOOT
   app/usage/settings
   app/theme
   app/contributing
+  app/modauthors
   app/credits
   app/changelog
 


### PR DESCRIPTION
To make it easier for mod authors to work with LOOT (and have LOOT work with their mod(s)), I've been meaning to write some documentation specifically for this segment, to make it as clear as possible what they can do to make LOOT get along with their mod(s) as best as possible.

It's in a *very* early stage, but suggestions and feedback are very welcome! The rendered page can be viewed at https://loot.readthedocs.io/en/mod-author-docs-section/app/modauthors.html