### PR TITLE
Compatibility with icu 61+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ IF (CMAKE_COMPILER_IS_GNUCXX)
     set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};.")
     set (CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 
-    set (LOOT_LIBS pthread http_parser ssh2 stdc++fs)
+    set (LOOT_LIBS pthread http_parser ssh2 stdc++fs icui18n)
     set (LOOT_GUI_LIBS X11 ${LOOT_LIBS})
     set (LOOT_TEST_LIBS ${LOOT_LIBS})
 ENDIF ()

--- a/src/gui/helpers.cpp
+++ b/src/gui/helpers.cpp
@@ -38,6 +38,7 @@
 #else
 #include <unicode/uchar.h>
 #include <unicode/unistr.h>
+using icu::UnicodeString;
 #endif
 
 #include "gui/state/logging.h"


### PR DESCRIPTION
ICU 61 and higher (tested with 64.2) needs a using added - http://site.icu-project.org/download/61#TOC-Migration-Issues

(same issue as in https://github.com/loot/libloot/pull/62)

---

Additionally, I had to edit the CMakeLists.txt and add `icui18n` into `LOOT_LIBS` otherwise I'd get the following error: https://haste.rys.pw/raw/wojizijawe

Although I'm not sure if that is the proper way to fix this issue or if it wouldn't break the current builds? 