### PR TITLE
Translation Strings Cleanup

### DIFF
--- a/resources/l10n/bg/LC_MESSAGES/loot.po
+++ b/resources/l10n/bg/LC_MESSAGES/loot.po
@@ -1,15 +1,15 @@
 # LOOT - Bulgarian Translation
 # Copyright (C) 2020 WrinklyNinja
 # This file is distributed under the same license as the LOOT package.
-# Georgi Georgiev <georgiev_1994@abv.bg>, 2020.
+# Georgi Georgiev <g.georgiev.shumen@gmail.com>, 2020, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: LOOT 0.14.0\n"
 "Report-Msgid-Bugs-To: https://github.com/loot/loot/issues\n"
 "POT-Creation-Date: 2019-08-21 22:37+0100\n"
-"PO-Revision-Date: 2020-09-22 22:56+0200\n"
-"Last-Translator: Georgi Georgiev <georgiev_1994@abv.bg>\n"
+"PO-Revision-Date: 2021-02-22 10:33+0200\n"
+"Last-Translator: Georgi Georgiev <g.georgiev.shumen@gmail.com>\n"
 "Language-Team: Bulgarian\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
@@ -98,7 +98,7 @@ msgid ""
 "This can cause issues in-game, and sorting will fail while this plugin is "
 "installed."
 msgstr ""
-"Тази приставка е основна за \"%1%\" и я изисква. "
+"Тази приставка се нуждае от \"%1%\". "
 "Това може да създаде проблеми в играта и сортирането няма да е успешно, "
 "докато тя е инсталирана."
 
@@ -161,8 +161,8 @@ msgid ""
 "fixed within hours."
 msgstr ""
 "Най-новата ревизия на основния списък съдържа синтактична грешка, LOOT "
-"ще използва най-новата валидна версия на негово място. Обикновено "
-"синтактичните грешки не са големи и биват поправени за няколко часа."
+"ще използва най-новата валидна версия на негово място. Синтактичните "
+"грешки са лесни за отстраняване и биват поправени за няколко часа."
 
 #: src/gui/state/game/game.cpp:630
 msgid ""
@@ -185,7 +185,7 @@ msgstr ""
 "\n"
 "Моля, обновете основния списък за да поправите грешката. Ако грешката е "
 "в потребителските метаданни, причината може да е в обновяване на LOOT, "
-"което е възможно да е променило синтаксиса. Потребителските метданни "
+"което е променило поддържания синтаксис. Потребителските метданни "
 "трябва да се обновят ръчно.\n"
 "\n"
 "За да го направите, отворете 'Отвори Файла за регистриране на грешки' "
@@ -551,7 +551,7 @@ msgstr "Програма за почистване"
 
 #: src/gui/html/js/translateStaticText.ts:275
 msgid "URL"
-msgstr "URL"
+msgstr "Връзка"
 
 #: src/gui/html/js/translateStaticText.ts:279
 #: src/gui/html/js/translateStaticText.ts:683
@@ -620,7 +620,7 @@ msgstr "Изисква се CRC."
 #: src/gui/html/js/translateStaticText.ts:383
 #: src/gui/html/js/translateStaticText.ts:388
 msgid "Values must be integers."
-msgstr "Стойнотите трябва да са цели числа."
+msgstr "Стойностите трябва да са цели числа."
 
 #: src/gui/html/js/translateStaticText.ts:393
 #: src/gui/html/js/translateStaticText.ts:410
@@ -712,7 +712,7 @@ msgstr "Филтри"
 
 #: src/gui/html/js/translateStaticText.ts:569
 msgid "Press Enter or click outside the input to set the filter."
-msgstr "Натиснете Enter или с цъкнете извън полето, за да зададете филтъра."
+msgstr "Натиснете Enter или натиснете извън полето, за да зададете филтъра."
 
 #: src/gui/html/js/translateStaticText.ts:573
 msgid "Show only plugins with cards that contain"
@@ -724,7 +724,7 @@ msgstr "Не е посочен текст"
 
 #: src/gui/html/js/translateStaticText.ts:579
 msgid "Hide version numbers"
-msgstr "Скрий номера на версията"
+msgstr "Скрий версията"
 
 #: src/gui/html/js/translateStaticText.ts:582
 msgid "Hide CRCs"
@@ -737,10 +737,6 @@ msgstr "Скрий Bash етикетите"
 #: src/gui/html/js/translateStaticText.ts:584
 msgid "Hide notes"
 msgstr "Скрий бележките"
-
-#: src/gui/html/js/translateStaticText.ts:585
-msgid "Hide 'Do not clean' messages"
-msgstr "Скрий съобщенията 'Не почиствай'"
 
 #: src/gui/html/js/translateStaticText.ts:588
 msgid "Hide all plugin messages"
@@ -832,7 +828,7 @@ msgstr "Обнови основния списък преди сортиране
 
 #: src/gui/html/js/translateStaticText.ts:680
 msgid "Check for LOOT updates on startup"
-msgstr "Провери за обновявания при стартирането на LOOT"
+msgstr "Проверявай за обновявания при стартирането на LOOT"
 
 #: src/gui/html/js/translateStaticText.ts:686
 msgid "Base Game"
@@ -844,7 +840,7 @@ msgstr "Папка на LOOT"
 
 #: src/gui/html/js/translateStaticText.ts:695
 msgid "Masterlist Repository URL"
-msgstr "URL на хранилището на основния списък"
+msgstr "Връзка към хранилището на основния списък"
 
 #: src/gui/html/js/translateStaticText.ts:698
 msgid "Masterlist Repository Branch"
@@ -872,7 +868,7 @@ msgstr ""
 
 #: src/gui/html/js/translateStaticText.ts:739
 msgid "Click %(menu_icon)s buttons to open menus."
-msgstr "Цъкнете върху %(menu_icon)s за да отворите менютата."
+msgstr "Натиснете върху %(menu_icon)s за да отворите менютата."
 
 #: src/gui/html/js/translateStaticText.ts:746
 msgid ""
@@ -899,7 +895,7 @@ msgid ""
 "Double-click a plugin in the sidebar to quickly open it in the metadata "
 "editor."
 msgstr ""
-"Цъкнете два пъти върху приставка в страничната лента за нейното "
+"Натиснете два пъти върху приставка в страничната лента за нейното "
 "бързо отваряне в редактора за метаданни."
 
 #: src/gui/html/js/translateStaticText.ts:755
@@ -936,8 +932,7 @@ msgid ""
 "using %s."
 msgstr ""
 "LOOT е безплатен, но ако искате да направите дарение, може да подкрепите "
-"WrinklyNinja (той е създателя на LOOT и главния разработчик) "
-"чрез %s."
+"WrinklyNinja (той е създател и главен разработчик на LOOT) чрез %s."
 
 #: src/gui/html/js/translateStaticText.ts:770
 msgid "OK"

--- a/resources/l10n/cs/LC_MESSAGES/loot.po
+++ b/resources/l10n/cs/LC_MESSAGES/loot.po
@@ -555,10 +555,6 @@ msgstr "Schovat Bash Tagy"
 msgid "Hide notes"
 msgstr "Schovat poznámky"
 
-#: src/gui/html/js/translateStaticText.js:459
-msgid "Hide 'Do not clean' messages"
-msgstr "Schovat \"Neuklízet\" Zprávy"
-
 #: src/gui/html/js/translateStaticText.js:461
 msgid "Hide all plugin messages"
 msgstr "Schovat všechny zprávy pluginů"

--- a/resources/l10n/da/LC_MESSAGES/loot.po
+++ b/resources/l10n/da/LC_MESSAGES/loot.po
@@ -627,12 +627,6 @@ msgid "Hidden plugins:"
 msgstr "Skjulte plugins:"
 
 #
-# File: src/gui/html/js/translateStaticText.js, line: 471
-# File: src/gui/html/js/translateStaticText.js, line: 471
-msgid "Hide 'Do not clean' messages"
-msgstr "Skjul “Rengør ikke”‐beskeder"
-
-#
 # File: src/gui/html/js/translateStaticText.js, line: 464
 # File: src/gui/html/js/translateStaticText.js, line: 464
 msgid "Hide Bash Tags"

--- a/resources/l10n/de/LC_MESSAGES/loot.po
+++ b/resources/l10n/de/LC_MESSAGES/loot.po
@@ -763,10 +763,6 @@ msgstr "Bash Tags ausblenden"
 msgid "Hide notes"
 msgstr "Notizen ausblenden"
 
-#: src/gui/html/js/translateStaticText.ts:585
-msgid "Hide 'Do not clean' messages"
-msgstr "'Nicht säubern'-Nachrichten ausblenden"
-
 #: src/gui/html/js/translateStaticText.ts:588
 msgid "Hide all plugin messages"
 msgstr "Alle aktiven Plugins ausblenden"

--- a/resources/l10n/es/LC_MESSAGES/loot.po
+++ b/resources/l10n/es/LC_MESSAGES/loot.po
@@ -908,10 +908,6 @@ msgstr "Ocultar Sugerencias Bash Tag(s)"
 msgid "Hide Notes"
 msgstr "Ocultar Notas"
 
-#: backend/generators.h:555
-msgid "Hide 'Do Not Clean' Messages"
-msgstr "Ocultar mensajes 'No Se Limpia'"
-
 #: backend/generators.h:563
 msgid "Hide All Plugin Messages"
 msgstr "Ocultar todos los mensajes de los Plugins"

--- a/resources/l10n/fi/LC_MESSAGES/loot.po
+++ b/resources/l10n/fi/LC_MESSAGES/loot.po
@@ -1029,10 +1029,6 @@ msgstr "Piilota Bash-tagiehdotukset"
 msgid "Hide Notes"
 msgstr "Piilota huomautukset"
 
-#: backend/generators.h:491
-msgid "Hide 'Do Not Clean' Messages"
-msgstr "Piilota \"älä puhdista\"-viestit"
-
 #: backend/generators.h:499
 msgid "Hide All Plugin Messages"
 msgstr "Piilota kaikki lisäosaviestit"

--- a/resources/l10n/fr/LC_MESSAGES/loot.po
+++ b/resources/l10n/fr/LC_MESSAGES/loot.po
@@ -437,10 +437,6 @@ msgstr "Masquer les étiquettes bash"
 msgid "Hide notes"
 msgstr "Masquer les notes"
 
-#: src/gui/html/js/translateStaticText.js:201
-msgid "Hide 'Do not clean' messages"
-msgstr "Masquer les messages 'Ne pas nettoyer'"
-
 #: src/gui/html/js/translateStaticText.js:202
 msgid "Hide all plugin messages"
 msgstr "Masquer les messages des plugins"

--- a/resources/l10n/ja/LC_MESSAGES/loot.po
+++ b/resources/l10n/ja/LC_MESSAGES/loot.po
@@ -692,10 +692,6 @@ msgstr "Bash Tagsを隠す"
 msgid "Hide notes"
 msgstr "メモを隠す"
 
-#: src/gui/html/js/translateStaticText.js:459
-msgid "Hide 'Do not clean' messages"
-msgstr "'クリーン禁止' メッセージを隠す"
-
 #: src/gui/html/js/translateStaticText.js:460
 msgid "Hide all plugin messages"
 msgstr "全てのプラグインのメッセージを隠す"

--- a/resources/l10n/ko/LC_MESSAGES/loot.po
+++ b/resources/l10n/ko/LC_MESSAGES/loot.po
@@ -691,10 +691,6 @@ msgstr "배쉬 태그 숨기기"
 msgid "Hide notes"
 msgstr "노트 숨기기"
 
-#: resources/report/js/l10n.js:250
-msgid "Hide 'Do not clean' messages"
-msgstr "'청소 금지'메시지 숨기기"
-
 #: resources/report/js/l10n.js:251
 msgid "Hide all plugin messages"
 msgstr "모든 플러그인 메시지 숨기기"

--- a/resources/l10n/pl/LC_MESSAGES/loot.po
+++ b/resources/l10n/pl/LC_MESSAGES/loot.po
@@ -1019,10 +1019,6 @@ msgstr "Ukryj sugestie tagów Bash"
 msgid "Hide Notes"
 msgstr "Ukryj notatki"
 
-#: backend/generators.h:490
-msgid "Hide 'Do Not Clean' Messages"
-msgstr "Ukryj wiadomości \"Nie czyścić\""
-
 #: backend/generators.h:498
 msgid "Hide All Plugin Messages"
 msgstr "Ukryj wszystkie wiadomości wtyczek"

--- a/resources/l10n/pt_BR/LC_MESSAGES/loot.po
+++ b/resources/l10n/pt_BR/LC_MESSAGES/loot.po
@@ -481,10 +481,6 @@ msgstr "Marcações Bash"
 msgid "Hide notes"
 msgstr "Esconder Notas"
 
-#: resources/report/js/l10n.js:157
-msgid "Hide 'Do not clean' messages"
-msgstr "Esconder Mensagem 'Não limpe'"
-
 #: resources/report/js/l10n.js:158
 msgid "Hide inactive plugin messages"
 msgstr "Esconder as Mensagens do Plugin Inativo"

--- a/resources/l10n/ru/LC_MESSAGES/loot.po
+++ b/resources/l10n/ru/LC_MESSAGES/loot.po
@@ -699,10 +699,6 @@ msgstr "Скрыть bash-теги"
 msgid "Hide notes"
 msgstr "Скрыть примечания"
 
-#: src/gui/html/js/translateStaticText.js:459
-msgid "Hide 'Do not clean' messages"
-msgstr "Скрыть сообщения 'Не чистить'"
-
 #: src/gui/html/js/translateStaticText.js:460
 msgid "Hide all plugin messages"
 msgstr "Скрыть все сообщения плагинов"

--- a/resources/l10n/sv/LC_MESSAGES/loot.po
+++ b/resources/l10n/sv/LC_MESSAGES/loot.po
@@ -440,10 +440,6 @@ msgstr "Dölj bashtaggar"
 msgid "Hide notes"
 msgstr "Dölj anteckningar"
 
-#: src/gui/html/js/translateStaticText.js:201
-msgid "Hide 'Do not clean' messages"
-msgstr "Dölj meddelandet \"Rensa inte\""
-
 #: src/gui/html/js/translateStaticText.js:202
 msgid "Hide all plugin messages"
 msgstr "Dölj alla insticksmodulmeddelanden"

--- a/resources/l10n/template.pot
+++ b/resources/l10n/template.pot
@@ -692,10 +692,6 @@ msgstr ""
 msgid "Hide notes"
 msgstr ""
 
-#: src/gui/html/js/translateStaticText.ts:585
-msgid "Hide 'Do not clean' messages"
-msgstr ""
-
 #: src/gui/html/js/translateStaticText.ts:588
 msgid "Hide all plugin messages"
 msgstr ""

--- a/resources/l10n/zh_CN/LC_MESSAGES/loot.po
+++ b/resources/l10n/zh_CN/LC_MESSAGES/loot.po
@@ -483,10 +483,6 @@ msgstr "隐藏Bash标签"
 msgid "Hide notes"
 msgstr "隐藏注释"
 
-#: src/gui/html/js/translateStaticText.js:255
-msgid "Hide 'Do not clean' messages"
-msgstr "隐藏 '不要清理' 信息"
-
 #: src/gui/html/js/translateStaticText.js:256
 msgid "Hide all plugin messages"
 msgstr "隐藏所有插件信息"


### PR DESCRIPTION
With this PR I removed the string 'Hide do not clean' messages from every translation file, including the template. Also I made a few small corrections to the Bulgarian translation as a bonus. :smile_cat: 

I'm not entirely sure if this is the only string which needs to be removed after the closing of bug #1407 , please, correct me if I'm wrong and I will make additional commits as needed.

Regards,
Georgi