### PR TITLE
Reword incompatibility message

### DIFF
--- a/resources/l10n/template.pot
+++ b/resources/l10n/template.pot
@@ -85,7 +85,7 @@ msgid "This plugin requires \"%1%\" to be active, but it is inactive."
 msgstr ""
 
 #: src/gui/state/game/game.cpp:240
-msgid "This plugin is incompatible with \"%1%\", but both files are present."
+msgid "This plugin is incompatible with \"%1%\", but both are present."
 msgstr ""
 
 #: src/gui/state/game/game.cpp:276

--- a/src/gui/state/game/game.cpp
+++ b/src/gui/state/game/game.cpp
@@ -227,7 +227,7 @@ std::vector<Message> Game::CheckInstallValidity(
           (!hasPluginFileExtension(file) || IsPluginActive(file))) {
         if (logger) {
           logger->error(
-              "\"{}\" is incompatible with \"{}\", but both files are present.",
+              "\"{}\" is incompatible with \"{}\", but both are present.",
               plugin->GetName(),
               file);
         }
@@ -238,7 +238,7 @@ std::vector<Message> Game::CheckInstallValidity(
             Message(MessageType::error,
                     (boost::format(boost::locale::translate(
                          "This plugin is incompatible with \"%1%\", but both "
-                         "files are present.")) %
+                         "are present.")) %
                      inc.GetDisplayName())
                         .str()));
         displayNamesWithMessages.insert(inc.GetDisplayName());

--- a/src/tests/gui/state/game/game_test.h
+++ b/src/tests/gui/state/game/game_test.h
@@ -303,7 +303,7 @@ TEST_P(GameTest,
                 Message(MessageType::error,
                         "This plugin is incompatible with \"" +
                             EscapeMarkdownSpecialChars(masterFile) +
-                            "\", but both files are present."),
+                            "\", but both are present."),
             }),
             messages);
 }
@@ -329,7 +329,7 @@ TEST_P(
           Message(MessageType::error,
                         "This plugin is incompatible with \"" +
                             EscapeMarkdownSpecialChars(incompatibleFilename) +
-                      "\", but both files are present."),
+                      "\", but both are present."),
       }),
       messages);
 }
@@ -350,7 +350,7 @@ TEST_P(
   EXPECT_EQ(std::vector<Message>({
                 Message(MessageType::error,
                         "This plugin is incompatible with \"foo\", but both "
-                        "files are present."),
+                        "are present."),
             }),
             messages);
 }
@@ -375,7 +375,7 @@ TEST_P(
   EXPECT_EQ(std::vector<Message>({
                 Message(MessageType::error,
                         "This plugin is incompatible with \"test file\", but "
-                        "both files are present."),
+                        "both are present."),
             }),
             messages);
 }


### PR DESCRIPTION
I just removed "files" so that it's less awkward when a `display` value that isn't a file is passed.