### PR TITLE
Revert "Update credits"

### DIFF
--- a/docs/app/credits.rst
+++ b/docs/app/credits.rst
@@ -17,7 +17,7 @@ In addition, the following are credited with application-related support:
   * Danish: Freso
   * Finnish: 3ventic
   * French: Kaos, cpasmoi, Sita
-  * German: lpradel, DaCoolX, Infernio, pStyl3, Deka-O
+  * German: lpradel, DaCoolX, Infernio, pStyl3
   * Italian: Griam, nicola89b, albie
   * Japanese: kuroko, tktk11
   * Korean: SteamB23, sean-kang


### PR DESCRIPTION
Reverts loot/loot#1488.

Didn't realize they were another account for a contributor already listed.