### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -52,16 +52,16 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Boost cache
         id: boost-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ steps.boost-metadata.outputs.root }}/boost
@@ -87,7 +87,7 @@ jobs:
 
       - name: OGDF cache
         id: ogdf-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.OGDF_INSTALL_PATH }}
           key: ${{ runner.os }}-ogdf-${{ env.OGDF_VERSION }}
@@ -221,7 +221,7 @@ jobs:
         if: github.event_name == 'push'
 
       - name: Upload archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build-archive.outputs.filename }}
           path: |
@@ -230,7 +230,7 @@ jobs:
         if: github.event_name == 'push'
 
       - name: Upload Flatpak package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build-flatpak.outputs.filename }}
           path: |
@@ -242,16 +242,16 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -269,7 +269,7 @@ jobs:
 
       - name: Boost cache
         id: boost-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ steps.boost-metadata.outputs.root }}/boost
@@ -278,7 +278,7 @@ jobs:
 
       - name: OGDF cache
         id: ogdf-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.OGDF_INSTALL_PATH }}
           key: ${{ runner.os }}-x64-ogdf-${{ env.OGDF_VERSION }}
@@ -393,7 +393,7 @@ jobs:
         if: github.event_name == 'push'
 
       - name: Upload archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get-artifact-basename.outputs.basename }}.7z
           path: |
@@ -402,7 +402,7 @@ jobs:
         if: github.event_name == 'push'
 
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get-artifact-basename.outputs.basename }}.exe
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,16 +52,16 @@ jobs:
     needs: create_release
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Boost cache
         id: boost-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ steps.boost-metadata.outputs.root }}/boost
@@ -87,7 +87,7 @@ jobs:
 
       - name: OGDF cache
         id: ogdf-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.OGDF_INSTALL_PATH }}
           key: ${{ runner.os }}-ogdf-${{ env.OGDF_VERSION }}
@@ -191,11 +191,11 @@ jobs:
     needs: create_release
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -212,7 +212,7 @@ jobs:
 
       - name: Boost cache
         id: boost-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ steps.boost-metadata.outputs.root }}/boost
@@ -221,7 +221,7 @@ jobs:
 
       - name: OGDF cache
         id: ogdf-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.OGDF_INSTALL_PATH }}
           key: ${{ runner.os }}-x64-ogdf-${{ env.OGDF_VERSION }}


### PR DESCRIPTION
This PR updates outdated actions in the GitHub Actions workflows.

The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v4
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* update [`actions/setup-python`](https://github.com/actions/setup-python) to v5
* update [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to v4

Still using the outdated actions will generate several warnings in CI runs, for example in https://github.com/loot/loot/actions/runs/8030443480:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings, because the newer versions of those actions use Node.js 20.