### PR TITLE
Remove fuzzy lines from Turkish translation

### DIFF
--- a/resources/l10n/tr_TR/LC_MESSAGES/loot.po
+++ b/resources/l10n/tr_TR/LC_MESSAGES/loot.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the LOOT package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: LOOT 0.22.4\n"
@@ -324,7 +323,6 @@ msgstr "Grupları &Düzenle…"
 
 #. translators: This string is an action in the Game menu.
 #: src/gui/qt/main_window.cpp:734
-#, fuzzy
 msgid "Searc&h Cards…"
 msgstr "Kartları &Ara…"
 


### PR DESCRIPTION
The `#, fuzzy` lines aren't needed, and none of the other translations include a single one of them. The second `#, fuzzy` line led to Poedit thinking that `Searc&h Cards…` wasn't translated, or better said that the existing translation `Kartları &Ara…` "Needs Work" - while it's fine as is.