### PR TITLE
fix diff calculation typo, UI crashes, thread termination, and unnecessary allocations

### DIFF
--- a/src/gui/qt/compare_load_orders_dialog.cpp
+++ b/src/gui/qt/compare_load_orders_dialog.cpp
@@ -143,7 +143,7 @@ std::vector<std::vector<int>> traceShortestPath(
     const std::vector<QListWidgetItem*>& list2) {
   size_t maxPathLength = list1.size() + list2.size();
   int list1Size = throwingCastToInt(list1.size());
-  int64_t list2Size = throwingCastToInt64(list1.size());
+  int64_t list2Size = throwingCastToInt64(list2.size());
 
   // Indexes are values of maxPathLength + k, so when k = -maxPathLength
   // the index is 0, when k = 0 it's maxPathLength, and when k = maxPathLength

--- a/src/gui/qt/plugin_editor/table_tabs.cpp
+++ b/src/gui/qt/plugin_editor/table_tabs.cpp
@@ -392,11 +392,6 @@ MessageContentTableWidget::MessageContentTableWidget(
 void MessageContentTableWidget::initialiseInputs(
     std::vector<MessageContent>&& nonUserMetadata,
     std::vector<MessageContent>&& userMetadata) {
-  std::map<MessageType, std::pair<QString, QVariant>> messageTypeMap = {
-      {MessageType::say, {qTranslate("Note"), QString("say")}},
-      {MessageType::warn, {qTranslate("Warning"), QString("warn")}},
-      {MessageType::error, {qTranslate("Error"), QString("error")}}};
-
   auto tableModel = new MessageContentTableModel(
       this, std::move(nonUserMetadata), std::move(userMetadata), languageMap);
 

--- a/src/gui/qt/plugin_item_model.cpp
+++ b/src/gui/qt/plugin_item_model.cpp
@@ -525,12 +525,16 @@ void PluginItemModel::setPluginItems(std::vector<PluginItem>&& newItems) {
     endRemoveRows();
   }
 
-  beginInsertRows(QModelIndex(), 1, static_cast<int>(newItems.size()));
+  if (!newItems.empty()) {
+    beginInsertRows(QModelIndex(), 1, static_cast<int>(newItems.size()));
+  }
 
   std::swap(items, newItems);
   searchResults.resize(items.size(), false);
 
-  endInsertRows();
+  if (!items.empty()) {
+    endInsertRows();
+  }
 }
 
 void PluginItemModel::setEditorPluginName(

--- a/src/gui/qt/settings/settings_dialog.cpp
+++ b/src/gui/qt/settings/settings_dialog.cpp
@@ -184,7 +184,6 @@ void SettingsDialog::addGameTab(const GameSettings& settings,
 
 void SettingsDialog::removeTab(int index) {
   auto item = listWidget->takeItem(index);
-  delete item->listWidget();
   delete item;
 
   auto tab = stackedWidget->widget(index);

--- a/src/gui/qt/tasks/check_for_update_task.cpp
+++ b/src/gui/qt/tasks/check_for_update_task.cpp
@@ -248,12 +248,16 @@ void CheckForUpdateTask::onGetBuildCommitReplyFinished() {
     }
 
     if (tagCommitDate.value() > buildCommitDate.value()) {
-      logger->info("Tag date: {}, build date: {}",
-                   tagCommitDate.value().toString().toStdString(),
-                   buildCommitDate.value().toString().toStdString());
+      if (logger) {
+        logger->info("Tag date: {}, build date: {}",
+                     tagCommitDate.value().toString().toStdString(),
+                     buildCommitDate.value().toString().toStdString());
+      }
       emit finished(true);
-    } else if (logger) {
-      logger->info("No LOOT update is available.");
+    } else {
+      if (logger) {
+        logger->info("No LOOT update is available.");
+      }
       emit finished(false);
     }
   } catch (const std::exception& e) {

--- a/src/gui/query/types/get_game_data_query.h
+++ b/src/gui/query/types/get_game_data_query.h
@@ -24,6 +24,10 @@
 #ifndef LOOT_GUI_QUERY_GET_GAME_DATA_QUERY
 #define LOOT_GUI_QUERY_GET_GAME_DATA_QUERY
 
+#include <mutex>
+#include <thread>
+#include <vector>
+
 #include "gui/query/query.h"
 #include "gui/state/game/game.h"
 #include "gui/translate.h"
@@ -46,6 +50,7 @@ public:
        the game data, so also load the metadata lists. */
     bool isFirstLoad = game_->getPlugins().empty();
 
+    std::mutex exceptionMutex;
     std::exception_ptr exceptionPointer;
     std::vector<std::thread> threads;
 
@@ -53,6 +58,7 @@ public:
       try {
         game_->loadAllInstalledPlugins(true);
       } catch (...) {
+        std::lock_guard<std::mutex> lock(exceptionMutex);
         if (exceptionPointer == nullptr) {
           exceptionPointer = std::current_exception();
         }
@@ -64,6 +70,7 @@ public:
         try {
           game_->loadMetadata();
         } catch (...) {
+          std::lock_guard<std::mutex> lock(exceptionMutex);
           if (exceptionPointer == nullptr) {
             exceptionPointer = std::current_exception();
           }
@@ -76,6 +83,7 @@ public:
         game_->getCreationClubPlugins().load(
             game_->getSettings().getId(), game_->getSettings().getGamePath());
       } catch (...) {
+        std::lock_guard<std::mutex> lock(exceptionMutex);
         if (exceptionPointer == nullptr) {
           exceptionPointer = std::current_exception();
         }
@@ -85,10 +93,11 @@ public:
     for (auto& thread : threads) {
       if (thread.joinable()) {
         thread.join();
-        if (exceptionPointer != nullptr) {
-          std::rethrow_exception(exceptionPointer);
-        }
       }
+    }
+
+    if (exceptionPointer != nullptr) {
+      std::rethrow_exception(exceptionPointer);
     }
 
     // Sort plugins into their load order.

--- a/src/gui/state/game/detection/detail.cpp
+++ b/src/gui/state/game/detection/detail.cpp
@@ -95,15 +95,17 @@ std::vector<GameInstall> deduplicateGameInstalls(
     if (duplicate == uniqueGameInstalls.end()) {
       uniqueGameInstalls.push_back(gameInstall);
     } else {
-      logger->warn(
-          "Discarding game install for {} installed from {} to {} as a "
-          "duplicate of the install for {} installed from {} to {}",
-          getGameName(gameInstall.gameId),
-          getSourceDescription(gameInstall.source),
-          gameInstall.installPath.u8string(),
-          getGameName(duplicate->gameId),
-          getSourceDescription(duplicate->source),
-          duplicate->installPath.u8string());
+      if (logger) {
+        logger->warn(
+            "Discarding game install for {} installed from {} to {} as a "
+            "duplicate of the install for {} installed from {} to {}",
+            getGameName(gameInstall.gameId),
+            getSourceDescription(gameInstall.source),
+            gameInstall.installPath.u8string(),
+            getGameName(duplicate->gameId),
+            getSourceDescription(duplicate->source),
+            duplicate->installPath.u8string());
+      }
     }
   }
 


### PR DESCRIPTION
- **Fixed `list2Size` initialization in Myers diff computation (`compare_load_orders_dialog.cpp`):**
  - *What:* Changed `int64_t list2Size = throwingCastToInt64(list1.size());` to compute the size of `list2`.
  - *Why:* When comparing load orders of differing sizes, `list2Size` was initialized to the length of `list1`. This caused the path tracing loop to read out of bounds on `list2` (triggering `std::out_of_range` exceptions) or terminate early and fail the diff algorithm with a runtime error.

- **Fixed parent widget deletion in `SettingsDialog::removeTab` (`settings_dialog.cpp`):**
  - *What:* Removed `delete item->listWidget();`.
  - *Why:* `QListWidgetItem::listWidget()` returns a pointer to the parent `QListWidget` container itself rather than a custom item widget. Invoking `delete` on it destroyed the dialog's entire sidebar list, resulting in heap corruption and use-after-free crashes whenever tabs were removed or re-initialized.

- **Prevented `std::terminate()` crashes and data races during game data loading (`get_game_data_query.h`):**
  - *What:* Ensured all spawned worker threads are joined before rethrowing `exceptionPointer`, and guarded `exceptionPointer` assignments with a `std::mutex`.
  - *Why:* If an earlier worker thread threw an exception, checking and rethrowing inside the join loop exited the scope while subsequent threads were still active and joinable. Destroying joinable `std::thread` instances immediately invokes `std::terminate()`, crashing the process. In addition, multiple threads writing to `exceptionPointer` concurrently constituted an unsynchronized data race.

- **Fixed null logger dereference and update task deadlock (`check_for_update_task.cpp`):**
  - *What:* Added a null check to `logger->info` in the positive branch and decoupled `emit finished(false)` from the `logger` check in the negative branch.
  - *Why:* If `getLogger()` returned `nullptr`, the previous code dereferenced a null pointer when an update was available, and failed to emit the `finished(false)` signal when no update was available, causing any future awaiting the task to hang indefinitely.

- **Guarded invalid row insertion ranges in `PluginItemModel` (`plugin_item_model.cpp`):**
  - *What:* Wrapped `beginInsertRows` and `endInsertRows` in a check for `!newItems.empty()`.
  - *Why:* When clearing the model or providing an empty plugin list, passing `0` as the item count resulted in `beginInsertRows(QModelIndex(), 1, 0)`. Because Qt requires `first <= last`, this violated internal model constraints, leading to debug assertions and corrupted view index tracking.

- **Added null check for logger in game install deduplication (`detail.cpp`):**
  - *What:* Added an `if (logger)` guard prior to calling `logger->warn`.
  - *Why:* If logging initialization fails or returns `nullptr`, unconditionally dereferencing `logger` causes a crash when duplicate game installs are encountered.

- **Removed dead `messageTypeMap` allocation in `MessageContentTableWidget` (`table_tabs.cpp`):**
  - *What:* Deleted the unused `messageTypeMap` local variable from `initialiseInputs()`.
  - *Why:* This map was an artifact from copying `MessageTableTab` setup code and was never passed to or read by `MessageContentTableModel`. Removing it eliminates redundant heap allocations and unnecessary translation lookups on every open.